### PR TITLE
Add OSRF invite discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ If the repositories of the subproject are under the WG's GitHub organization, th
 
 Any news to be shared, meeting announcements or discussion points should be on the [Aerial Vehicles category on ROS discourse](https://discourse.ros.org/c/aerial-vehicles/).
 
-Quick chats, meeting reminders, subcommittee communication or just for fun sharing is on the [#cwg-aerial channel](https://discord.com/channels/1077825543698927656/1141902822254850128) in the [OSRF discord Server](https://discord.com/invite/RtJeHT8mXQ).
+Quick chats, meeting reminders, subcommittee communication or just for fun sharing is on the [ROS Aerial Discord Channel (Open Robotics Server)](https://discord.gg/open-robotics-1077825543698927656).
 
 
 ### Backlog Management

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ If the repositories of the subproject are under the WG's GitHub organization, th
 
 Any news to be shared, meeting announcements or discussion points should be on the [Aerial Vehicles category on ROS discourse](https://discourse.ros.org/c/aerial-vehicles/).
 
-Quick chats, meeting reminders, subcommittee communication or just for fun sharing is on the [#cwg-aerial channel in the ROS discord Server](https://discord.com/channels/1077825543698927656/1141902822254850128)
+Quick chats, meeting reminders, subcommittee communication or just for fun sharing is on the [#cwg-aerial channel](https://discord.com/channels/1077825543698927656/1141902822254850128) in the [OSRF discord Server](https://discord.com/invite/RtJeHT8mXQ).
 
 
 ### Backlog Management


### PR DESCRIPTION
During the last aerial ROS meeting, it took me a little while to find how to access the discord channel since I was not part of the discord server yet and discord just fails on the channel link if one is not part of the server. I had to search for the server and I discovered that it is actually not called *ROS* (anymore?).

This PR changes the link with the one that was in the last meeting minute. This link works even if not already in the server.